### PR TITLE
Tutorial show bug

### DIFF
--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -1,6 +1,11 @@
 class TutorialsController < ApplicationController
   def show
     tutorial = Tutorial.find(params[:id])
-    @facade = TutorialFacade.new(tutorial, params[:video_id])
+    if tutorial.videos.empty?
+      flash[:notice] = "The tutorial you selected has no videos."
+      redirect_to root_path
+    else
+      @facade = TutorialFacade.new(tutorial, params[:video_id])
+    end
   end
 end

--- a/spec/features/vistors/vistor_sees_a_video_show_spec.rb
+++ b/spec/features/vistors/vistor_sees_a_video_show_spec.rb
@@ -1,16 +1,31 @@
 require 'rails_helper'
 
-describe 'visitor sees a video show' do
-  it 'vistor clicks on a tutorial title from the home page' do
-    tutorial = create(:tutorial)
-    video = create(:video, tutorial_id: tutorial.id)
+describe 'As a Visitor' do
+  describe 'visitor sees a video show' do
+    it 'vistor clicks on a tutorial title from the home page' do
+      tutorial = create(:tutorial)
+      video = create(:video, tutorial_id: tutorial.id)
 
-    visit '/'
+      visit '/'
 
-    click_on tutorial.title
+      click_on tutorial.title
 
-    expect(current_path).to eq(tutorial_path(tutorial))
-    expect(page).to have_content(video.title)
-    expect(page).to have_content(tutorial.title)
+      expect(current_path).to eq(tutorial_path(tutorial))
+      expect(page).to have_content(video.title)
+      expect(page).to have_content(tutorial.title)
+    end
+  end
+
+  describe 'when they visit a tutorial show page' do
+    it 'only shows valid tutorials' do
+      tutorial = create(:tutorial)
+
+      visit '/'
+
+      click_on tutorial.title
+
+      expect(current_path).to eq(root_path)
+      expect(page).to have_content("The tutorial you selected has no videos.")
+    end
   end
 end


### PR DESCRIPTION
Adds implementation of Tutorial show page won't load if missing videos.  I used a conditional in the show action of the Tutorials controller that checks if there are videos associated with the tutorial. If there aren't any, it delivers a flash message and redirects to the root page .  Test for this user story is passing, some previous tests are failing (friendship problems).